### PR TITLE
Changed youtube regex to match id-s in more links

### DIFF
--- a/stepmania/code/SMBBCodeDefinitionSet.php
+++ b/stepmania/code/SMBBCodeDefinitionSet.php
@@ -37,11 +37,11 @@ class YoutubeEmbed extends JBBCode\CodeDefinition {
 		foreach($el->getChildren() as $child)
 			$content .= $child->getAsBBCode();
 			
-		$foundMatch = preg_match('/v=([A-z0-9=\-]+?)(&.*)?$/i', $content, $matches);
+		$foundMatch = preg_match('/(\?v=|\/\d\/|\/embed\/|\/v\/|\.be\/)([a-zA-Z0-9\-\_]+)/', $content, $matches);
 		if(!$foundMatch)
 			return $el->getAsBBCode();
 		else
-			return "<iframe width=\"640\" height=\"390\" src=\"http://www.youtube.com/embed/".$matches[1]."\" frameborder=\"0\" allowfullscreen></iframe>";
+			return "<iframe width=\"640\" height=\"390\" src=\"http://www.youtube.com/embed/".$matches[2]."\" frameborder=\"0\" allowfullscreen></iframe>";
 	}
 }
 


### PR DESCRIPTION
This regex is a little slower but matches every possible youtube link format I could find.

Found in [this answer](http://stackoverflow.com/questions/8388223/youtube-url-id-regex).

[Tested here](http://www.phpliveregex.com/p/30A).

Since I have no development tools here (github edit button is all I need), I haven't tested that my commit works, but there weren't many things to mess up so I'm optimistic.

The only thing it doesn't match but should is `[youtube]1nV2EocffQ0[/youtube]`.
