### PR TITLE
[abbr] for abbreviations and a few bbcode fixes

### DIFF
--- a/stepmania/code/SMBBCodeDefinitionSet.php
+++ b/stepmania/code/SMBBCodeDefinitionSet.php
@@ -84,7 +84,7 @@ class SMBBCodeDefinitionSet implements JBBCode\CodeDefinitionSet
 
 		/* [img=alt text] image tag */
 		$builder = new JBBCode\CodeDefinitionBuilder('img', '<img src="{param}" alt="{option}" />');
-		$builder->setUseOption(true)->setBodyValidator($urlValidator);
+		$builder->setUseOption(true)->setParseContent(false)->setBodyValidator($urlValidator);
 		array_push($this->definitions, $builder->build());
 
 		/* [color] color tag */


### PR DESCRIPTION
Since I have no idea how to send a push request that does not include all my commits (should I do a branch-per-feature approach?), this is a 4 in 1 push request.
1. [abbr=description]abbreviation[/abbr] tag to make [abbreviations](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr) available. This accidentaly implements #24 (not exactly as per request but makes similar results possible), so I commited it. This feature might need custom css later on (dashed underline, a little questionmark, etc).
2. The src attribute's quote was not closed, this made the `[img=alt]` tag very quirky (only the one with the alt attribute present).
3. The same tag also had it's alt attribute validated as url instead of it's src attribute.
4. It is actually possible to use `[` and `]` characters in urls, so in theory there could be bbcodes in there. Content parsing should be disabled for the `src` attributes of images.
