### PR TITLE
There is no need for double encode, but single quotes should be encoded.

### DIFF
--- a/stepmania/code/SMBBCodeParser.php
+++ b/stepmania/code/SMBBCodeParser.php
@@ -116,8 +116,7 @@ class SMBBCodeParser extends TextParser {
 	 * @return Text
 	 */
 	public function parse() {
-		$this->content = htmlspecialchars($this->content);
-		$this->content = htmlentities($this->content);
+		$this->content = htmlentities($this->content, ENT_QUOTES);
 
 		$parser = new JBBCode\Parser();
 		$parser->addCodeDefinitionSet(new SMBBCodeDefinitionSet());


### PR DESCRIPTION
[`htmlentities()`](http://php.net/htmlentities) encodes everything [`htmlspecialchars()`](http://php.net/htmlspecialchars) does, but more.

The double encode would make all signs that are special html chars `>` `<` `"` `&` unreadable, but does not provide anything securitywise.
