### PR TITLE
don't hijack the reply link if there is no reason to

### DIFF
--- a/stepmania/javascript/site.js
+++ b/stepmania/javascript/site.js
@@ -32,20 +32,22 @@
 	});
 
 	$(".replyLink").click(function(){
-		var post = $(this);
-		var postData = {
-			id: post.attr("x-post-id"),
-			user: post.attr("x-post-author"),
-			data: post.attr("x-post-data")
-		};
-		editor.val(
-			editor.val() +
-			"[quote=" + postData.user + "]" +
-			postData.data +
-			"[/quote]\n"
-		);
-		editor.focus();
-		return false;
+        if (editor.length > 0) {
+            var post = $(this);
+            var postData = {
+                id: post.attr("x-post-id"),
+                user: post.attr("x-post-author"),
+                data: post.attr("x-post-data")
+            };
+            editor.val(
+                editor.val() +
+                "[quote=" + postData.user + "]" +
+                postData.data +
+                "[/quote]\n"
+            );
+            editor.focus();
+            return false;
+        }
 	});
 
     /* Forum stuff */


### PR DESCRIPTION
If there is no editor on the page the reply links get `preventDefault()`-ed without any real effect.
This checks if there is actually an editor on the page.
