### PR TITLE
Latest post calculation fix

### DIFF
--- a/forum/code/model/Post.php
+++ b/forum/code/model/Post.php
@@ -62,12 +62,12 @@ class Post extends DataObject {
 
 	/**
 	 * After saving this post, update the {@link ForumThread} with information
-	 * that this is now the most recent post
+	 * that the most recent post could have changed.
 	 */
 	function onAfterWrite() {
 		parent::onAfterWrite();
 
-		// Tell the thread this is the most recently added or edited.
+		// Force thread to recalculate it's most recent.
 		if ($this->ThreadID) $this->Thread()->updateLastPost();
 	}
 


### PR DESCRIPTION
This proposal fixes #39 .

I know it is debatable that the last post is the last one edited not the last one created, but it since most forum engines went with the latter, it was confusing.

Also since the creation date for the post is also shown there, it hinted that there are no posts in the thread after the date shown, which is not always true.

The forum list also shows the post last created. It is reasonable that the 2 places should work the same way.
