### PR TITLE
Post looping order is not really dependable it seems

### DIFF
--- a/themes/stepmania/templates/Layout/HomePage.ss
+++ b/themes/stepmania/templates/Layout/HomePage.ss
@@ -5,7 +5,7 @@ $Content
 	<% with NewsForum %>
 		<% if Topics %>
 		<% loop Topics.Limit(15) %>
-			<% loop Posts(1).Limit(1) %>
+			<% with FirstPost %>
 	<div id="post{$ID}" class="forum-post">
 		<header>
 			<h2><a href="$Link">$Title</a></h2>
@@ -52,7 +52,7 @@ $Content
 			</span>
 		</footer>
 	</div>
-			<% end_loop %>
+			<% end_with %>
 		<% end_loop %>
 		<% end_if %>
 	<% end_with %>


### PR DESCRIPTION
Just look at the home page. The first post there is a reply. `loop Posts(1).Limit(1)` somehow selected the reply to be shown. Managed to get similar results locally by editing the first post and replies randomly in a news topic.

The FirstPost property works better.
