### PR TITLE
fix Rainbow text for Forums

### DIFF
--- a/stepmania/javascript/site.js
+++ b/stepmania/javascript/site.js
@@ -1,19 +1,21 @@
 (function($){$(function(){
 	// https://github.com/xoxco/rainbow-text
-	$(".rainbow").rainbow({
-		colors: [
-			'#FF0000',
-			'#f26522',
-			'#fff200',
-			'#00a651',
-			'#28abe2',
-			'#2e3192',
-			'#6868ff'
-		],
-		animate: true,
-		animateInterval: 200,
-		pad: false,
-		pauseLength: 100
+	$(".rainbow").each(function(){
+		$(this).rainbow({
+			colors: [
+				'#FF0000',
+				'#f26522',
+				'#fff200',
+				'#00a651',
+				'#28abe2',
+				'#2e3192',
+				'#6868ff'
+			],
+			animate: true,
+			animateInterval: 200,
+			pad: false,
+			pauseLength: 100
+		});
 	});
 
 	$("#Form_AdminFormFeatures").hide();


### PR DESCRIPTION
If a single page in a thread contained multiple instances of the rainbow markup, the existing JavaScript would make the text of each match the last instance found.  This behavior exists in the original implementation ( https://github.com/xoxco/rainbow-text ) as can be seen here: http://jsfiddle.net/nzv2L259/

This is a simple fix: iterate over all instances of p.rainbow found and apply the rainbow() function to each individually.

There are valid arguments that doing this with a plain JavaScript for loop is faster; I'm not sure it's really worth worrying about at this time.
